### PR TITLE
fixed error with updating status of question when responded to on slack

### DIFF
--- a/src/screens/Mentors.js
+++ b/src/screens/Mentors.js
@@ -216,10 +216,11 @@ export default class Mentors extends Component<Props> {
         let questions = await AsyncStorage.getItem("questions")
         var qList = JSON.parse(questions)
         // update status of question
-        qList.forEach(element => {
+        qList.forEach((element, index) => {
           if (element.question == question){
             console.log("found!")
             element.status = "Responded!"
+            qList[index] = element
           }
         })
         // store update in local storage


### PR DESCRIPTION
Made a silly mistake with updating the copy of the element in the question list instead of the question list itself. Tested it on iOS as well. 